### PR TITLE
JSON error with enums: get().toString instead of getString() used

### DIFF
--- a/src/main/java/com/bmwcarit/barefoot/markov/Filter.java
+++ b/src/main/java/com/bmwcarit/barefoot/markov/Filter.java
@@ -196,7 +196,7 @@ public abstract class Filter<C extends StateCandidate<C, T, S>, T extends StateT
                 if (candidate_.filtprob() == 0) {
                     continue;
                 }
-
+                candidate_.time(sample.time());
                 candidate_.filtprob(candidate_.filtprob() * candidate.two());
                 result.add(candidate_);
 
@@ -217,6 +217,7 @@ public abstract class Filter<C extends StateCandidate<C, T, S>, T extends StateT
                 normsum += candidate.two();
                 candidate_.filtprob(candidate.two());
                 candidate_.seqprob(Math.log10(candidate.two()));
+                candidate_.time(sample.time());
                 result.add(candidate_);
 
                 if (logger.isTraceEnabled()) {

--- a/src/main/java/com/bmwcarit/barefoot/markov/StateCandidate.java
+++ b/src/main/java/com/bmwcarit/barefoot/markov/StateCandidate.java
@@ -32,6 +32,7 @@ public class StateCandidate<C extends StateCandidate<C, T, S>, T extends StateTr
     private T transition = null;
     private double seqprob = 0d;
     private double filtprob = 0d;
+    private long time = 0L;
 
     /**
      * Creates a {@link StateCandidate} object and generates a random UUID.
@@ -66,6 +67,7 @@ public class StateCandidate<C extends StateCandidate<C, T, S>, T extends StateTr
         // This does not handle infinite values.
         filtprob = json.getDouble("filtprob");
         seqprob = json.getDouble("seqprob");
+        time = (factory.sample(json).time());
     }
 
     /**
@@ -167,6 +169,25 @@ public class StateCandidate<C extends StateCandidate<C, T, S>, T extends StateTr
         if (transition != null) {
             json.put("transition", transition().toJSON());
         }
+        json.put("time", time);
         return json;
     }
+
+    /**
+     * Gets time of sample for state candidate.
+     *
+     * @return time of point.
+     */
+	public long time() {
+		return time;
+	}
+
+	 /**
+     * Sets time of the state candidate.
+     *
+     * @param time of point from sample.
+     */
+	public void time(long time) {
+		this.time = time;
+	}
 }

--- a/src/main/java/com/bmwcarit/barefoot/markov/StateCandidate.java
+++ b/src/main/java/com/bmwcarit/barefoot/markov/StateCandidate.java
@@ -19,174 +19,190 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * State candidate in Hidden Markov Model (HMM) inference e.g. with a HMM filter {@link Filter}. A
- * state candidate refers to a possible state with some probability as part of a stochastic process.
+ * State candidate in Hidden Markov Model (HMM) inference e.g. with a HMM filter
+ * {@link Filter}. A state candidate refers to a possible state with some
+ * probability as part of a stochastic process.
  *
- * @param <C> Candidate inherits from {@link StateCandidate}.
- * @param <T> Transition inherits from {@link StateTransition}.
- * @param <S> Sample inherits from {@link Sample}.
+ * @param <C>
+ *            Candidate inherits from {@link StateCandidate}.
+ * @param <T>
+ *            Transition inherits from {@link StateTransition}.
+ * @param <S>
+ *            Sample inherits from {@link Sample}.
  */
 public class StateCandidate<C extends StateCandidate<C, T, S>, T extends StateTransition, S extends Sample> {
-    private final String id;
-    private C predecessor = null;
-    private T transition = null;
-    private double seqprob = 0d;
-    private double filtprob = 0d;
-    private long time = 0L;
+	private final String id;
+	private C predecessor = null;
+	private T transition = null;
+	private double seqprob = 0d;
+	private double filtprob = 0d;
+	private long time = 0L;
 
-    /**
-     * Creates a {@link StateCandidate} object and generates a random UUID.
-     */
-    public StateCandidate() {
-        id = UUID.randomUUID().toString();
-    }
+	/**
+	 * Creates a {@link StateCandidate} object and generates a random UUID.
+	 */
+	public StateCandidate() {
+		id = UUID.randomUUID().toString();
+	}
 
-    /**
-     * Creates {@link StateCandidate} object with a specific identifier.
-     *
-     * @param id Object identifier (should be unique in {@link StateMemory} context).
-     */
-    public StateCandidate(String id) {
-        this.id = id;
-    }
+	/**
+	 * Creates {@link StateCandidate} object with a specific identifier.
+	 *
+	 * @param id
+	 *            Object identifier (should be unique in {@link StateMemory}
+	 *            context).
+	 */
+	public StateCandidate(String id) {
+		this.id = id;
+	}
 
-    /**
-     * Creates {@link StateCandidate} object from its JSON representation.
-     *
-     * @param json JSON representation of an {@link StateCandidate} object.
-     * @param factory {@link Factory} object for construction of state candidates and transitions.
-     * @throws JSONException thrown on JSON extraction or parsing error.
-     */
-    public StateCandidate(JSONObject json, Factory<C, T, S> factory) throws JSONException {
-        id = json.getString("id");
-        JSONObject jsontrans = json.optJSONObject("transition");
-        if (jsontrans != null) {
-            transition = factory.transition(jsontrans);
-        }
+	/**
+	 * Creates {@link StateCandidate} object from its JSON representation.
+	 *
+	 * @param json
+	 *            JSON representation of an {@link StateCandidate} object.
+	 * @param factory
+	 *            {@link Factory} object for construction of state candidates
+	 *            and transitions.
+	 * @throws JSONException
+	 *             thrown on JSON extraction or parsing error.
+	 */
+	public StateCandidate(JSONObject json, Factory<C, T, S> factory) throws JSONException {
+		id = json.getString("id");
+		JSONObject jsontrans = json.optJSONObject("transition");
+		if (jsontrans != null) {
+			transition = factory.transition(jsontrans);
+		}
 
-        // This does not handle infinite values.
-        filtprob = json.getDouble("filtprob");
-        seqprob = json.getDouble("seqprob");
-        time = (factory.sample(json).time());
-    }
+		// This does not handle infinite values.
+		filtprob = json.getDouble("filtprob");
+		seqprob = json.getDouble("seqprob");
+		time = json.getLong("time");
+	}
 
-    /**
-     * Gets identifier of state candidate.
-     *
-     * @return Identifier of state candidate.
-     */
-    public String id() {
-        return id;
-    }
+	/**
+	 * Gets identifier of state candidate.
+	 *
+	 * @return Identifier of state candidate.
+	 */
+	public String id() {
+		return id;
+	}
 
-    /**
-     * Gets predecessor in the most likely sequence to this state candidate. If there is no such
-     * sequence it's null.
-     *
-     * @return Predecessor in the most likely sequence to this state candidate, if it exists
-     *         otherwise null.
-     */
-    public C predecessor() {
-        return predecessor;
-    }
+	/**
+	 * Gets predecessor in the most likely sequence to this state candidate. If
+	 * there is no such sequence it's null.
+	 *
+	 * @return Predecessor in the most likely sequence to this state candidate,
+	 *         if it exists otherwise null.
+	 */
+	public C predecessor() {
+		return predecessor;
+	}
 
-    /**
-     * Sets predecessor in the most likely sequence to this state candidate.
-     *
-     * @param predecessor Most likely predecessor state candidate.
-     */
-    public void predecessor(C predecessor) {
-        this.predecessor = predecessor;
-    }
+	/**
+	 * Sets predecessor in the most likely sequence to this state candidate.
+	 *
+	 * @param predecessor
+	 *            Most likely predecessor state candidate.
+	 */
+	public void predecessor(C predecessor) {
+		this.predecessor = predecessor;
+	}
 
-    /**
-     * Gets transition from predecessor, if it exists otherwise null.
-     *
-     * @return Transition from predecessor, if it exists otherwise null.
-     */
-    public T transition() {
-        return transition;
-    }
+	/**
+	 * Gets transition from predecessor, if it exists otherwise null.
+	 *
+	 * @return Transition from predecessor, if it exists otherwise null.
+	 */
+	public T transition() {
+		return transition;
+	}
 
-    /**
-     * Sets transition from predecessor, if it exists otherwise null.
-     *
-     * @param transition Transition from most likely predecessor state candidate.
-     */
-    public void transition(T transition) {
-        this.transition = transition;
-    }
+	/**
+	 * Sets transition from predecessor, if it exists otherwise null.
+	 *
+	 * @param transition
+	 *            Transition from most likely predecessor state candidate.
+	 */
+	public void transition(T transition) {
+		this.transition = transition;
+	}
 
-    /**
-     * Gets sequence probability of the state candidate (logarithmic scaled with
-     * <i>log<sub>10</sub></i>).
-     *
-     * @return State candidate's sequence probability.
-     */
-    public double seqprob() {
-        return seqprob;
-    }
+	/**
+	 * Gets sequence probability of the state candidate (logarithmic scaled with
+	 * <i>log<sub>10</sub></i>).
+	 *
+	 * @return State candidate's sequence probability.
+	 */
+	public double seqprob() {
+		return seqprob;
+	}
 
-    /**
-     * Sets sequence probability of the state candidate (logarithmic scaled with
-     * <i>log<sub>10</sub></i>).
-     *
-     * @param seqprob Sequence probability
-     */
-    public void seqprob(double seqprob) {
-        this.seqprob = seqprob;
-    }
+	/**
+	 * Sets sequence probability of the state candidate (logarithmic scaled with
+	 * <i>log<sub>10</sub></i>).
+	 *
+	 * @param seqprob
+	 *            Sequence probability
+	 */
+	public void seqprob(double seqprob) {
+		this.seqprob = seqprob;
+	}
 
-    /**
-     * Gets filter probability of the state candidate.
-     *
-     * @return Filter probability.
-     */
-    public double filtprob() {
-        return filtprob;
-    }
+	/**
+	 * Gets filter probability of the state candidate.
+	 *
+	 * @return Filter probability.
+	 */
+	public double filtprob() {
+		return filtprob;
+	}
 
-    /**
-     * Sets filter probability of the state candidate.
-     *
-     * @param filtprob Filter probability.
-     */
-    public void filtprob(double filtprob) {
-        this.filtprob = filtprob;
-    }
+	/**
+	 * Sets filter probability of the state candidate.
+	 *
+	 * @param filtprob
+	 *            Filter probability.
+	 */
+	public void filtprob(double filtprob) {
+		this.filtprob = filtprob;
+	}
 
-    /**
-     * Gets a JSON representation of the state candidate.
-     *
-     * @return JSON representation of the state candidate.
-     * @throws JSONException thrown on JSON extraction or parsing error.
-     */
-    public JSONObject toJSON() throws JSONException {
-        JSONObject json = new JSONObject();
-        json.put("id", id);
-        json.put("filtprob", Double.isInfinite(filtprob) ? "Infinity" : filtprob);
-        json.put("seqprob", Double.isInfinite(seqprob) ? "-Infinity" : seqprob);
-        if (transition != null) {
-            json.put("transition", transition().toJSON());
-        }
-        json.put("time", time);
-        return json;
-    }
+	/**
+	 * Gets a JSON representation of the state candidate.
+	 *
+	 * @return JSON representation of the state candidate.
+	 * @throws JSONException
+	 *             thrown on JSON extraction or parsing error.
+	 */
+	public JSONObject toJSON() throws JSONException {
+		JSONObject json = new JSONObject();
+		json.put("id", id);
+		json.put("filtprob", Double.isInfinite(filtprob) ? "Infinity" : filtprob);
+		json.put("seqprob", Double.isInfinite(seqprob) ? "-Infinity" : seqprob);
+		if (transition != null) {
+			json.put("transition", transition().toJSON());
+		}
+		json.put("time", time);
+		return json;
+	}
 
-    /**
-     * Gets time of sample for state candidate.
-     *
-     * @return time of point.
-     */
+	/**
+	 * Gets time of sample for state candidate.
+	 *
+	 * @return time of point.
+	 */
 	public long time() {
 		return time;
 	}
 
-	 /**
-     * Sets time of the state candidate.
-     *
-     * @param time of point from sample.
-     */
+	/**
+	 * Sets time of the state candidate.
+	 *
+	 * @param time
+	 *            of point from sample.
+	 */
 	public void time(long time) {
 		this.time = time;
 	}

--- a/src/main/java/com/bmwcarit/barefoot/matcher/MatcherKState.java
+++ b/src/main/java/com/bmwcarit/barefoot/matcher/MatcherKState.java
@@ -187,6 +187,9 @@ public class MatcherKState extends KState<MatcherCandidate, MatcherTransition, M
 
         JSONArray candidates = new JSONArray();
         for (MatcherCandidate candidate : vector()) {
+        	if (candidate.filtprob() < 0.1)
+        		continue;
+        	
             JSONObject jsoncandidate = new JSONObject();
             jsoncandidate.put("point", GeometryEngine.geometryToWkt(candidate.point().geometry(),
                     WktExportFlags.wktExportPoint));

--- a/src/main/java/com/bmwcarit/barefoot/road/PostGISReader.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/PostGISReader.java
@@ -142,6 +142,7 @@ public class PostGISReader extends PostgresSource implements RoadReader {
                 long osmId = Long.parseLong(result_set.getString(2));
                 short classId = Short.parseShort(result_set.getString(3));
                 if (!config.containsKey(classId)) {
+                	logger.warn("Unknown class id {} found", classId);
                     continue;
                 }
                 long source = Long.parseLong(result_set.getString(4));

--- a/src/main/java/com/bmwcarit/barefoot/road/PostGISReader.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/PostGISReader.java
@@ -147,8 +147,7 @@ public class PostGISReader extends PostgresSource implements RoadReader {
                 }
                 long source = Long.parseLong(result_set.getString(4));
                 long target = Long.parseLong(result_set.getString(5));
-                // double length = Double.parseDouble(result_set.getString(6)) *
-                // 1000;
+
                 double reverse = Double.parseDouble(result_set.getString(7)) * 1000;
                 int maxspeedForward = result_set.getObject(8) == null ? config.get(classId).two()
                         : Integer.parseInt(result_set.getString(8));
@@ -160,7 +159,12 @@ public class PostGISReader extends PostgresSource implements RoadReader {
                 Polyline geometry = (Polyline) OperatorImportFromWkb.local().execute(
                         WkbImportFlags.wkbImportDefaults, Type.Polyline, ByteBuffer.wrap(wkb),
                         null);
-                float length = (float) spatial.length(geometry);
+                
+                float length;
+                if (result_set.getString(6).equals("1"))
+                	length = (float) spatial.length(geometry);
+                else
+                	length = Float.parseFloat(result_set.getString(6));
 
                 road = new BaseRoad(gid, source, target, osmId, reverse >= 0 ? false : true,
                         classId, priority, maxspeedForward, maxspeedBackward, length, wkb);

--- a/src/main/java/com/bmwcarit/barefoot/roadmap/Loader.java
+++ b/src/main/java/com/bmwcarit/barefoot/roadmap/Loader.java
@@ -18,6 +18,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -86,8 +87,9 @@ public class Loader {
         if (database == null) {
             throw new SourceException("could not read database properties");
         }
+        String pathDatabase = properties.getProperty("database.dir");
 
-        File file = new File(database + ".bfmap");
+        File file = new File(Paths.get(pathDatabase, database) + ".bfmap");
         RoadMap map = null;
 
         if (!file.exists() || !buffer) {

--- a/src/main/java/com/bmwcarit/barefoot/roadmap/Loader.java
+++ b/src/main/java/com/bmwcarit/barefoot/roadmap/Loader.java
@@ -87,7 +87,7 @@ public class Loader {
         if (database == null) {
             throw new SourceException("could not read database properties");
         }
-        String pathDatabase = properties.getProperty("database.dir");
+        String pathDatabase = properties.getProperty("database.dir", "");
 
         File file = new File(Paths.get(pathDatabase, database) + ".bfmap");
         RoadMap map = null;

--- a/src/main/java/com/bmwcarit/barefoot/roadmap/Road.java
+++ b/src/main/java/com/bmwcarit/barefoot/roadmap/Road.java
@@ -160,7 +160,7 @@ public class Road extends AbstractEdge<Road> {
      */
     public static Road fromJSON(JSONObject json, RoadMap map) throws JSONException {
         long baseid = json.getLong("road");
-        Road road = map.get(Heading.valueOf(json.getString("heading")) == Heading.forward
+        Road road = map.get(Heading.valueOf(json.get("heading").toString()) == Heading.forward
                 ? baseid * 2 : baseid * 2 + 1);
         if (road == null) {
             throw new JSONException("road id " + json.getLong("road") + " not found");


### PR DESCRIPTION
Hi @smattheis , 

we had an error in barefoot using a newer JSON library (e.g. json-20160810.jar), which we used in our proprietary code for some additional functionalities.
Turned out to be a problem with enum handling.  The patch seems to work with both JSON versions.

The second commit is the code for issue #30 . We tested it thorougly with our map and it working and fastening the matching process enourmously!

Regards,
Volker
