### PR TITLE
Support modification of speed limit extraction

### DIFF
--- a/map/tools/test/test_bfmap.py
+++ b/map/tools/test/test_bfmap.py
@@ -100,31 +100,53 @@ class TestBfmap(unittest.TestCase):
         segments = bfmap.segment(config, row)
         self.assertEquals(2, len(segments))
 
-    def test_maxspeed(self):
+    def test_extract_limit_number(self):
+        self.assertEquals(60, bfmap.extract_speed_limit("60"))
+
+    def test_extract_limit_space_mph(self):
+        self.assertEquals(60 * 1.609, bfmap.extract_speed_limit("60 mph"))
+
+    def test_extract_limit_nospace_mph(self):
+        self.assertEquals(60 * 1.609, bfmap.extract_speed_limit("60mph"))
+
+    def test_extract_limit_unrecognised(self):
+        self.assertEquals(None, bfmap.extract_speed_limit("national"))
+
+    def test_maxspeed_space_mph(self):
         tags = {"maxspeed": "60 mph"}
         (fwd, bwd) = bfmap.maxspeed(tags)
         self.assertEquals(60 * 1.609, fwd)
         self.assertEquals(60 * 1.609, bwd)
 
+    def test_maxspeed_number(self):
         tags = {"maxspeed": "60"}
         (fwd, bwd) = bfmap.maxspeed(tags)
         self.assertEquals(60, fwd)
         self.assertEquals(60, bwd)
 
+    def test_maxspeed_fb_space_mph(self):
         tags = {"maxspeed:forward": "60 mph", "maxspeed:backward": "60 mph"}
         (fwd, bwd) = bfmap.maxspeed(tags)
         self.assertEquals(60 * 1.609, fwd)
         self.assertEquals(60 * 1.609, bwd)
 
+    def test_maxspeed_fb_kph(self):
         tags = {"maxspeed:forward": "60", "maxspeed:backward": "60"}
         (fwd, bwd) = bfmap.maxspeed(tags)
         self.assertEquals(60, fwd)
         self.assertEquals(60, bwd)
 
+    def test_maxspeed_nospace_mph(self):
         tags = {"maxspeed": "60mph"}
         (fwd, bwd) = bfmap.maxspeed(tags)
-        self.assertEquals("null", fwd)
-        self.assertEquals("null", bwd)
+        self.assertEquals(60 * 1.609, fwd)
+        self.assertEquals(60 * 1.609, bwd)
+
+    def test_maxspeed_specific_overrides_general(self):
+        tags = {"maxspeed": "20", "maxspeed:backward": "30"}
+        (fwd, bwd) = bfmap.maxspeed(tags)
+        self.assertEquals(20, fwd)
+        self.assertEquals(30, bwd)
 
     def test_ways2bfmap(self):
         properties = dict(line.strip().split('=')

--- a/map/tools/test/test_bfmap.py
+++ b/map/tools/test/test_bfmap.py
@@ -149,8 +149,9 @@ class TestBfmap(unittest.TestCase):
         self.assertEquals(30, bwd)
 
     def test_ways2bfmap(self):
-        properties = dict(line.strip().split('=')
-                          for line in open('/mnt/map/tools/test/test.properties'))
+        from os.path import join, dirname, abspath
+        prop_file = join(dirname(abspath(__file__)), 'test.properties')
+        properties = dict(line.strip().split('=') for line in open(prop_file))
         bfmap.schema("localhost", 5432, properties[
                      "database"], "bfmap_ways", properties["user"], properties["password"], False)
         config = bfmap.config(properties["config"])


### PR DESCRIPTION
OSM maps for UK occassionally use integers for speed limits in MPH. Also, some roads have textual limits like "national". To handle these properly, it is useful to be able to simply modify the code that interprets the OSM maxspeed tags. For presentation purposes it can also be useful to allow represention of the speed limit in the database in MPH.

To simplify modification of the map ingest to support such modifications, this patch separates the interpretation of the speed limit string into a separate function `extract_speed_limit`.

In addition, the patch:
- supports speed limits with no space between the number and "mph"
- replaces the hard-wired path in one test with a generated path
- adds an `__init__.py` file to allow testing to be run using `python -m unittest discover` from the `tools` directory
- cleans up some minor PEP8 style issues

The patch does not actually support the UK-specific cleanups or use of MPH. Those changes need to be added separately (and other national variations may exist).
