### PR TITLE
Prevent stack overflow during KState remove

### DIFF
--- a/src/main/java/com/bmwcarit/barefoot/markov/KState.java
+++ b/src/main/java/com/bmwcarit/barefoot/markov/KState.java
@@ -234,15 +234,18 @@ public class KState<C extends StateCandidate<C, T, S>, T extends StateTransition
     }
 
     protected void remove(C candidate, int index) {
-        Set<C> vector = sequence.get(index).one();
-        counters.remove(candidate);
-        vector.remove(candidate);
-
-        C predecessor = candidate.predecessor();
-        if (predecessor != null) {
-            counters.put(predecessor, counters.get(predecessor) - 1);
-            if (counters.get(predecessor) == 0) {
-                remove(predecessor, index - 1);
+        while (candidate != null) {
+            Set<C> vector = sequence.get(index).one();
+            counters.remove(candidate);
+            vector.remove(candidate);
+            candidate = candidate.predecessor();
+            if (candidate != null) {
+                counters.put(candidate, counters.get(candidate) - 1);
+                if (counters.get(candidate) == 0) {
+                    index -= 1;
+                } else {
+                    candidate = null;
+                }
             }
         }
     }

--- a/src/test/java/com/bmwcarit/barefoot/markov/KStateTest.java
+++ b/src/test/java/com/bmwcarit/barefoot/markov/KStateTest.java
@@ -252,6 +252,22 @@ public class KStateTest {
     }
 
     @Test
+    public void TestKStateRemoveLongSequence() {
+        // KState remove code was originally recursive, but this could cause a
+        // stack overflow.  This tests that removing a long sequence succeeds 
+        // without causing an exception.
+        KState<MockElem, StateTransition, Sample> state = new KState<>(-1, -1);
+        MockElem candidate = null;
+        int i = 0;
+        for (i = 0; i < 10000; ++i) {
+            candidate = new MockElem(i, Math.log10(0.3), 0.3, candidate);
+            Set<MockElem> vector = new HashSet<>(Arrays.asList(candidate));
+            state.update(vector, new Sample(i));
+        }
+        state.remove(candidate, i - 1);
+    }
+
+    @Test
     public void TestTState() {
         Map<Integer, MockElem> elements = new HashMap<>();
         elements.put(0, new MockElem(0, Math.log10(0.3), 0.3, null));

--- a/src/test/java/com/bmwcarit/barefoot/matcher/ServerTest.java
+++ b/src/test/java/com/bmwcarit/barefoot/matcher/ServerTest.java
@@ -58,8 +58,8 @@ public class ServerTest {
 
     private void sendRequest(InetAddress host, int port, JSONArray samples)
             throws InterruptedException, IOException, JSONException {
-        int trials = 120;
-        int timeout = 500;
+        int trials = 300;
+        int timeout = 1000;
         Socket client = null;
 
         while (client == null || !client.isConnected()) {
@@ -69,7 +69,9 @@ public class ServerTest {
                 Thread.sleep(timeout);
 
                 if (trials == 0) {
-                    client.close();
+                    if (client != null) {
+                        client.close();
+                    }
                     throw new IOException(e.getMessage());
                 } else {
                     trials -= 1;

--- a/src/test/java/com/bmwcarit/barefoot/tracker/TrackerServerTest.java
+++ b/src/test/java/com/bmwcarit/barefoot/tracker/TrackerServerTest.java
@@ -61,8 +61,8 @@ public class TrackerServerTest {
 
     public void sendSample(InetAddress host, int port, JSONObject sample)
             throws InterruptedException, IOException {
-        int trials = 120;
-        int timeout = 500;
+        int trials = 300;
+        int timeout = 1000;
         Socket client = null;
 
         while (client == null || !client.isConnected()) {
@@ -73,8 +73,10 @@ public class TrackerServerTest {
 
                 if (trials == 0) {
                     logger.error(e.getMessage());
-                    client.close();
-                    throw new IOException();
+                    if (client != null) {
+                        client.close();
+                    }
+                    throw new IOException(e.getMessage());
                 } else {
                     trials -= 1;
                 }
@@ -92,8 +94,8 @@ public class TrackerServerTest {
 
     public MatcherKState requestState(InetAddress host, int port, String id)
             throws JSONException, InterruptedException, IOException {
-        int trials = 120;
-        int timeout = 500;
+        int trials = 300;
+        int timeout = 1000;
         Socket client = null;
 
         while (client == null || !client.isConnected()) {
@@ -104,8 +106,10 @@ public class TrackerServerTest {
 
                 if (trials == 0) {
                     logger.error(e.getMessage());
-                    client.close();
-                    throw new IOException();
+                    if (client != null) {
+                        client.close();
+                    }
+                    throw new IOException(e.getMessage());
                 } else {
                     trials -= 1;
                 }


### PR DESCRIPTION
During map-matching, I was seeing occassional failures due to StackOverflow:
```
17/06/23 04:02:11 WARN TaskSetManager: Lost task 1351.0 in stage 3.0 (TID 12713, 172.17.20.7): org.apache.spark.SparkException: Task failed while writing rows
	at org.apache.spark.sql.execution.datasources.DefaultWriterContainer.writeRows(WriterContainer.scala:269)
	at org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelation$$anonfun$run$1$$anonfun$apply$mcV$sp$3.apply(InsertIntoHadoopFsRelation.scala:148)
	at org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelation$$anonfun$run$1$$anonfun$apply$mcV$sp$3.apply(InsertIntoHadoopFsRelation.scala:148)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:66)
	at org.apache.spark.scheduler.Task.run(Task.scala:89)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:227)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.StackOverflowError
	at java.util.HashMap.removeNode(HashMap.java:846)
	at java.util.HashMap.remove(HashMap.java:798)
	at java.util.HashSet.remove(HashSet.java:235)
	at com.bmwcarit.barefoot.markov.KState.remove(KState.java:239)
	at com.bmwcarit.barefoot.markov.KState.remove(KState.java:245)
	at com.bmwcarit.barefoot.markov.KState.remove(KState.java:245)
	at com.bmwcarit.barefoot.markov.KState.remove(KState.java:245)
...
```

This appears to be due to the recursive form of the `KState.remove` method. This PR rewrites the code to be non-recursive, to stop this error occurring.

I also set a longer timeout for the server tests, so that they work in my environment. Although not directly connected, it allows all tests to pass in slower environments.
