### PR TITLE
Changed so json data on request is the same json format as data sent to the zeromq.

### DIFF
--- a/src/main/java/com/bmwcarit/barefoot/tracker/TrackerServer.java
+++ b/src/main/java/com/bmwcarit/barefoot/tracker/TrackerServer.java
@@ -228,7 +228,7 @@ public class TrackerServer extends AbstractServer {
                                 State state = memory.getIfExistsLocked(id);
 
                                 if (state != null) {
-                                    response.append(state.inner.toJSON().toString());
+                                    response.append(state.inner.toMonitorJSON().toString());
                                     state.unlock();
                                 } else {
                                     JSONObject empty = new JSONObject();
@@ -296,6 +296,7 @@ public class TrackerServer extends AbstractServer {
                 JSONObject json = state.inner.toMonitorJSON();
                 json.put("id", id);
                 queue.put(json.toString());
+                logger.debug(json.toString());
             } catch (Exception e) {
                 logger.error("update failed: {}", e.getMessage());
                 e.printStackTrace();


### PR DESCRIPTION
Hi,

I have been integrating barefoot into transiTime.

[https://github.com/TheTransitClock/transitime/tree/barefoot](https://github.com/TheTransitClock/transitime/tree/barefoot)

I am wondering if this matches your intention or is there a reason the json format in these two cases differ?

Thanks in advance,
Sean.

