### PR TITLE
Simplify passphrase grep check

### DIFF
--- a/map/osm/import.sh
+++ b/map/osm/import.sh
@@ -44,7 +44,7 @@ echo "Start creation of user and initialization of credentials ..."
 sudo -u postgres psql -c "CREATE USER \"${user}\" PASSWORD '${password}';"
 sudo -u postgres psql -c "GRANT ALL ON DATABASE \"${database}\" TO \"${user}\";"
 passphrase="localhost:5432:${database}:${user}:${password}"
-if [ ! -e ~/.pgpass ] || [ `less ~/.pgpass | grep -c "$passphrase"` -eq 0 ]
+if ! grep -q -s "$passphrase" ~/.pgpass
 then
 	echo "$passphrase" >> ~/.pgpass
 	chmod 0600 ~/.pgpass

--- a/map/samples/import.sh
+++ b/map/samples/import.sh
@@ -40,7 +40,7 @@ echo "Start creation of user and initialization of credentials ..."
 sudo -u postgres psql -c "CREATE USER ${user} PASSWORD '${password}';"
 sudo -u postgres psql -c "GRANT ALL ON DATABASE ${database} TO ${user};"
 passphrase="localhost:5432:${database}:${user}:${password}"
-if [ ! -e ~/.pgpass ] || [ `less ~/.pgpass | grep -c "$passphrase"` -eq 0 ]
+if ! grep -q -s "$passphrase" ~/.pgpass
 then
 	echo "$passphrase" >> ~/.pgpass
 	chmod 0600 ~/.pgpass


### PR DESCRIPTION
Since `grep` returns with exit code 0 when the search string is found, it can be used directly on the `if`.

Also, using the `-s` option there's no need to check if the file exists.