### PR TITLE
Simplify appending to env var JAVACMD_OPTIONS

### DIFF
--- a/map/osm/import.sh
+++ b/map/osm/import.sh
@@ -55,12 +55,7 @@ echo "Start population of OSM data (osmosis) ..."
 psql -h localhost -d ${database} -U ${user} -f /mnt/map/osm/pgsnapshot_schema_0.6.sql
 rm -rf /mnt/map/osm/tmp
 mkdir /mnt/map/osm/tmp
-if [ -z "$JAVACMD_OPTIONS" ]; then
-    JAVACMD_OPTIONS="-Djava.io.tmpdir=/mnt/map/osm/tmp"
-else
-    JAVACMD_OPTIONS="$JAVACMD_OPTIONS -Djava.io.tmpdir=/mnt/map/osm/tmp"
-fi
-export JAVACMD_OPTIONS
+export JAVACMD_OPTIONS="$JAVACMD_OPTIONS -Djava.io.tmpdir=/mnt/map/osm/tmp"
 osmosis --read-pbf file=${input} --tf accept-ways highway=* --write-pgsql user="${user}" password="${password}" database="${database}"
 echo "Done."
 


### PR DESCRIPTION
In default Bash, it is not an error to refer to an undeclared (or empty) variable. In that case, it will just expand to an empty string.

So there's no need to do the prior check, you can just append the new value right away.

Also, in Bash you can safely set and export on the same command.