### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         # Osmosis takes about 10 minutes to process the Oberbayern map used for testing, which coincides with
         # Travis' timeout for output updates.  Use `travis_wait` to extend the timeout.
         # Use interactive option to force bash to read .bashrc and add path to Osmosis.
-        - travis_wait docker exec barefoot-database /bin/bash -i /mnt/map/osm/import.sh
+        - docker exec barefoot-database /bin/bash -i /mnt/map/osm/import.sh
         # Start matcher server on port 1234
         - mvn --quiet -Dexec.executable="echo" -Dexec.args='-n ${project.version}' --non-recursive exec:exec > version
         - docker run -t -d --net=host --name="barefoot-matcher" -v ${PWD}:/mnt/barefoot --workdir /mnt/barefoot barefoot-map java -jar target/barefoot-`cat version`-matcher-jar-with-dependencies.jar --geojson config/server.properties config/oberbayern.properties
@@ -50,6 +50,9 @@ before_script:
   # Osmosis takes about 10 minutes to process the Oberbayern map used for testing, which coincides with
   # Travis' timeout for output updates.  Use `travis_wait` to extend the timeout.
   # Use interactive option to force bash to read .bashrc and add path to Osmosis.
-  - travis_wait docker exec barefoot-database /bin/bash -i /mnt/map/osm/import.sh
+  - docker exec barefoot-database /bin/bash -i /mnt/map/osm/import.sh
 script:
   - mvn test --batch-mode --errors
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
